### PR TITLE
Fix: PostCSS Tailwind build error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": "20.x"
   },
   "scripts": {
     "dev": "next dev --turbopack -p 3001",

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,5 +1,7 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };
 
 export default config;

--- a/work_logs/2025-01-22_module_alias_import_error_fix.md
+++ b/work_logs/2025-01-22_module_alias_import_error_fix.md
@@ -1,0 +1,186 @@
+# Module Alias Import エラー修正作業ログ
+
+作成日: 2025-01-22
+ブランチ名: `fix/module-alias-import-errors`
+
+## 概要
+Vercel のビルドで「Module not found: Can't resolve '@/lib/api'」などのモジュールエイリアスインポートエラーを解決するため、TypeScript と webpack の設定を修正しました。
+
+## エラーの詳細
+- エラーメッセージ: 
+  - `Module not found: Can't resolve '@/lib/api'`
+  - `Module not found: Can't resolve '@/store/useStore'`
+  - `Module not found: Can't resolve '@/components/CongestionDisplay'`
+  - その他複数のエイリアスインポートエラー
+- 発生箇所: `./src/app/areas/[id]/page.tsx` での import 文
+- 原因: tsconfig.json の baseUrl 設定欠如とパス設定の不備
+
+## 作業内容
+
+### 1. 問題の分析 [01:08]
+- work_logs ディレクトリの確認
+- tsconfig.json の設定確認
+- `baseUrl` 設定が存在しないことを発見
+
+### 2. tsconfig.json の修正 [01:10]
+#### 変更前:
+```json
+{
+  "compilerOptions": {
+    // ... 他の設定
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+#### 変更後:
+```json
+{
+  "compilerOptions": {
+    // ... 他の設定
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+### 3. ファイル存在確認 [01:11]
+- `src/lib/api.ts` - 存在確認 ✓
+- `src/store/useStore.ts` - 存在確認 ✓
+- `src/components/CongestionDisplay.tsx` - 存在確認 ✓
+- `src/components/charts/AgeDistributionChart.tsx` - 存在確認 ✓
+- `src/components/WasteSeparationContent.tsx` - 存在確認 ✓
+
+### 4. api.ts のエクスポート確認 [01:12]
+```typescript
+export const areaApi = { ... }
+export const wellbeingApi = { ... }
+export const congestionApi = { ... }
+```
+すべて正しくエクスポートされていることを確認
+
+### 5. next.config.js の修正 [01:15]
+#### webpack エイリアス設定を追加:
+```javascript
+const path = require('path')
+
+const nextConfig = {
+  // ... 他の設定
+  typescript: {
+    ignoreBuildErrors: false, // true から false に変更
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@': path.resolve(__dirname, './src'),
+    }
+    return config
+  },
+}
+```
+
+### 6. ビルドテスト [01:16]
+```bash
+npm run build
+# ✓ Compiled successfully
+# ✓ Checking validity of types
+# ✓ Generating static pages (16/16)
+```
+TypeScript の型チェックも含めて成功
+
+### 7. PR作成とマージ [01:18]
+- PR #8 作成: "Fix: Resolve module alias import errors for Vercel deployment"
+- main ブランチへマージ完了
+
+## 技術的詳細
+
+### TypeScript の Path Mapping
+1. **baseUrl の重要性**
+   - TypeScript コンパイラがパス解決の起点を知る必要がある
+   - baseUrl なしでは paths 設定が機能しない
+
+2. **paths 設定の形式**
+   - `"@/*": ["./src/*"]` - baseUrl からの相対パス
+   - ワイルドカード (*) でサブディレクトリも含む
+
+### Webpack エイリアス設定
+1. **二重の設定が必要な理由**
+   - TypeScript: 型チェック時のパス解決
+   - Webpack: バンドル時のパス解決
+   - 両方が一致している必要がある
+
+2. **実装詳細**
+   ```javascript
+   config.resolve.alias['@'] = path.resolve(__dirname, './src')
+   ```
+
+### CSR 対応の考慮事項
+- モジュール解決はビルド時のみ影響
+- ランタイムコードには変更なし
+- クライアントサイドレンダリングの動作は維持
+
+## 修正の効果
+1. **エラーの解消**
+   - すべてのモジュールエイリアスエラーが解決
+   - ビルドプロセスが正常に完了
+
+2. **型安全性の向上**
+   - `ignoreBuildErrors: false` により型エラーを検出可能
+   - より堅牢なビルドプロセス
+
+3. **保守性の向上**
+   - エイリアスインポートによりコードの可読性向上
+   - リファクタリング時のパス変更が容易
+
+## Vercel ビルド環境での注意点
+1. **キャッシュのクリア**
+   - 設定変更後は「Clear build cache」を有効化
+   - 古い設定の影響を排除
+
+2. **環境差異**
+   - ローカルとVercelで異なる動作の可能性
+   - 明示的な設定により差異を最小化
+
+3. **大文字小文字の区別**
+   - CI/本番環境では厳密に区別される
+   - ファイル名とインポートの完全一致が必要
+
+## 今後の確認事項
+
+1. **Vercel デプロイメント**
+   - モジュール解決エラーが解消されたか確認
+   - ビルドログでエラーがないか監視
+
+2. **パフォーマンス**
+   - バンドルサイズへの影響確認
+   - ビルド時間の変化を監視
+
+3. **開発体験**
+   - VSCode などのエディタでパス補完が機能するか
+   - 新規ファイル追加時のインポートが正しく動作するか
+
+## 関連ファイル
+
+### 修正したファイル:
+- `/frontend/tsconfig.json`（baseUrl と paths 設定）
+- `/frontend/next.config.js`（webpack エイリアスと TypeScript 設定）
+
+### 確認したファイル:
+- `/frontend/src/app/areas/[id]/page.tsx`
+- `/frontend/src/lib/api.ts`
+- `/frontend/src/store/useStore.ts`
+- その他のコンポーネントファイル
+
+### PR情報:
+- PR番号: #8
+- URL: https://github.com/masa321555/tokyo-wellbeing-map/pull/8
+- マージ時刻: 2025-01-22 01:18
+
+## まとめ
+Vercel のモジュールエイリアスインポートエラーを解決するため、TypeScript の baseUrl 設定追加と webpack エイリアス設定を実装しました。これにより、@/* 形式のインポートが正しく解決され、ビルドが成功するようになりました。
+
+作業完了時刻: 2025-01-22 01:20


### PR DESCRIPTION
## Summary
- Fixed PostCSS configuration error preventing Vercel builds
- Stabilized Node.js version to prevent auto-upgrades

## Error Fix
- Error: "Cannot find module '@tailwindcss/postcss'"
- Cause: Incorrect PostCSS plugin configuration format
- Solution: Changed from array to object notation in postcss.config.mjs

## Changes
1. **postcss.config.mjs**
   - Changed plugin format from array to object:
   ```js
   // Before
   plugins: ["@tailwindcss/postcss"]
   // After
   plugins: { "@tailwindcss/postcss": {} }
   ```

2. **package.json**
   - Changed Node.js engine from `>=20.0.0` to `20.x`
   - Prevents unexpected major version upgrades on Vercel

3. **Dependencies**
   - Regenerated node_modules and package-lock.json
   - Ensured @tailwindcss/postcss is properly installed

## Technical Details
- Using Tailwind CSS v4 with @import syntax
- PostCSS requires plugins to be specified as objects with options
- Node.js version pinning prevents breaking changes from auto-upgrades

## Test Results
- Local build successful: `npm run build` completes without errors
- All styles compile correctly with Tailwind CSS v4

## CSR Considerations
- No changes to client-side rendering
- PostCSS configuration only affects build process
- Runtime behavior remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)