### PR TITLE
Fix: Add childcare_supports to API response

### DIFF
--- a/backend/app/api/v1/endpoints_mongo/areas.py
+++ b/backend/app/api/v1/endpoints_mongo/areas.py
@@ -58,6 +58,14 @@ async def get_area(area_id: int):
     if waste_rules:
         area_dict["waste_rules"] = waste_rules.dict(exclude={"area", "id"})
     
+    # childcare_supportsを追加
+    if hasattr(area, 'childcare_supports') and area.childcare_supports:
+        # ChildcareSupportオブジェクトのリストをdictのリストに変換
+        supports_list = []
+        for support in area.childcare_supports:
+            supports_list.append(support.dict())
+        area_dict["childcare_supports"] = supports_list
+    
     # IDを整数に変換
     area_dict["id"] = area_id
     

--- a/backend/init_all_data.py
+++ b/backend/init_all_data.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+全データを初期化・インポートするスクリプト
+"""
+import subprocess
+import sys
+import time
+
+def run_script(script_path, description):
+    """スクリプトを実行"""
+    print(f"\n{'='*60}")
+    print(f"実行中: {description}")
+    print(f"{'='*60}")
+    
+    try:
+        result = subprocess.run(
+            [sys.executable, script_path],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print(result.stdout)
+        if result.stderr:
+            print(f"警告: {result.stderr}")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"エラー: {e}")
+        print(f"標準出力: {e.stdout}")
+        print(f"エラー出力: {e.stderr}")
+        return False
+
+def main():
+    """メイン処理"""
+    scripts = [
+        ("app/database/init_mongo_simple.py", "基本データの初期化"),
+        ("app/scripts/import_area_characteristics.py", "区の特徴データのインポート"),
+        ("app/scripts/import_childcare_support_to_mongo.py", "子育て支援データのインポート"),
+        ("app/scripts/update_all_station_data_mongo.py", "町名・駅情報のインポート"),
+    ]
+    
+    print("全データの初期化を開始します...")
+    print(f"開始時刻: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    
+    success_count = 0
+    for script_path, description in scripts:
+        if run_script(script_path, description):
+            success_count += 1
+        else:
+            print(f"\n{script_path} の実行に失敗しました")
+            
+        # 各スクリプトの間に少し待機
+        time.sleep(1)
+    
+    print(f"\n{'='*60}")
+    print(f"完了: {success_count}/{len(scripts)} のスクリプトが正常に実行されました")
+    print(f"終了時刻: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    
+    if success_count == len(scripts):
+        print("\n✅ 全てのデータが正常にインポートされました")
+    else:
+        print("\n⚠️ 一部のデータのインポートに失敗しました")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/app/areas/[id]/page.tsx
+++ b/frontend/src/app/areas/[id]/page.tsx
@@ -50,6 +50,11 @@ export default function AreaDetailPage() {
       if (areaData?.town_list) {
         console.log('Town list found:', areaData.town_list);
       }
+      if (areaData?.childcare_supports) {
+        console.log('Childcare supports found:', areaData.childcare_supports);
+      } else {
+        console.log('No childcare supports in response');
+      }
       
       setArea(areaData);
       setWellbeingScore(scoreData);


### PR DESCRIPTION
## 概要
詳細ページで子育て支援制度が表示されない問題を修正しました。

## 問題
- APIレスポンスに`childcare_supports`が含まれていない（nullが返される）
- MongoDBにはデータが保存されているが、APIエンドポイントで返されていない

## 修正内容

### 1. APIエンドポイントの修正
`backend/app/api/v1/endpoints_mongo/areas.py`に以下を追加：
```python
# childcare_supportsを追加
if hasattr(area, 'childcare_supports') and area.childcare_supports:
    # ChildcareSupportオブジェクトのリストをdictのリストに変換
    supports_list = []
    for support in area.childcare_supports:
        supports_list.append(support.dict())
    area_dict["childcare_supports"] = supports_list
```

### 2. データ初期化スクリプトの作成
`backend/init_all_data.py`を作成：
- 基本データの初期化
- 区の特徴データのインポート
- 子育て支援データのインポート
- 町名・駅情報のインポート

### 3. フロントエンドのデバッグログ追加
受信データの確認用にconsole.logを追加

## 必要な手順
本番環境で子育て支援データを表示するには、以下のスクリプトを実行してください：

```bash
# 全データを一括で初期化・インポート
cd backend
python init_all_data.py

# または個別に実行
python app/scripts/import_childcare_support_to_mongo.py
```

## 確認事項
- [x] APIエンドポイントの修正
- [x] データインポートスクリプトの動作確認
- [ ] 本番環境でのデータインポート
- [ ] フロントエンドでの表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)